### PR TITLE
Raw multipart upload option

### DIFF
--- a/android/src/main/java/com/vydia/RawMultipartUploadRequest.java
+++ b/android/src/main/java/com/vydia/RawMultipartUploadRequest.java
@@ -1,0 +1,99 @@
+package com.vydia.RNUploader;
+
+import android.content.Context;
+import android.content.Intent;
+
+import net.gotev.uploadservice.ContentType;
+import net.gotev.uploadservice.HttpUploadRequest;
+import net.gotev.uploadservice.Logger;
+import net.gotev.uploadservice.UploadFile;
+import net.gotev.uploadservice.UploadRequest;
+import net.gotev.uploadservice.UploadServiceBroadcastReceiver;
+import net.gotev.uploadservice.UploadTask;
+
+import java.io.FileNotFoundException;
+import java.net.MalformedURLException;
+
+/**
+ * HTTP/Multipart upload request with a pre-constructed payload.
+ *
+ * @author gotev (Aleksandar Gotev)
+ * @author eliasnaur
+ * @author textile
+ *
+ */
+public class RawMultipartUploadRequest extends HttpUploadRequest<RawMultipartUploadRequest> {
+
+    private static final String LOG_TAG = RawMultipartUploadRequest.class.getSimpleName();
+    private String boundary = "";
+
+    /**
+     * Creates a new raw multipart upload request.
+     *
+     * @param context application context
+     * @param uploadId unique ID to assign to this upload request.<br>
+     *                 It can be whatever string you want, as long as it's unique.
+     *                 If you set it to null or an empty string, an UUID will be automatically
+     *                 generated.<br> It's advised to keep a reference to it in your code,
+     *                 so when you receive status updates in {@link UploadServiceBroadcastReceiver},
+     *                 you know to which upload they refer to.
+     * @param serverUrl URL of the server side script that will handle the multipart form upload.
+     *                  E.g.: http://www.yourcompany.com/your/script
+     * @throws IllegalArgumentException if one or more arguments are not valid
+     * @throws MalformedURLException if the server URL is not valid
+     */
+    public RawMultipartUploadRequest(final Context context, final String uploadId, final String serverUrl)
+            throws IllegalArgumentException, MalformedURLException {
+        super(context, uploadId, serverUrl);
+    }
+
+    /**
+     * Creates a new raw multipart upload request and automatically generates an upload id, that will
+     * be returned when you call {@link UploadRequest#startUpload()}.
+     *
+     * @param context application context
+     * @param serverUrl URL of the server side script that will handle the multipart form upload.
+     *                  E.g.: http://www.yourcompany.com/your/script
+     * @throws IllegalArgumentException if one or more arguments are not valid
+     * @throws MalformedURLException if the server URL is not valid
+     */
+    public RawMultipartUploadRequest(final Context context, final String serverUrl)
+            throws MalformedURLException, IllegalArgumentException {
+        this(context, null, serverUrl);
+    }
+
+    @Override
+    protected void initializeIntent(Intent intent) {
+        super.initializeIntent(intent);
+        intent.putExtra(RawMultipartUploadTask.RAW_BOUNDARY, boundary);
+    }
+
+    @Override
+    protected Class<? extends UploadTask> getTaskClass() {
+        return RawMultipartUploadTask.class;
+    }
+
+    /**
+     * Sets the multipart payload for this upload request.
+     *
+     * @param filePath path to the payload file that you want to upload
+     * @throws FileNotFoundException if the file does not exist at the specified path
+     * @throws IllegalArgumentException if one or more parameters are not valid
+     * @return {@link RawMultipartUploadRequest}
+     */
+    public RawMultipartUploadRequest setPayload(final String filePath)
+            throws FileNotFoundException, IllegalArgumentException {
+        UploadFile file = new UploadFile(filePath);
+        params.addFile(file);
+        return this;
+    }
+
+    /**
+     * Sets the multipart boundary used in the payload.
+     * @return request instance
+     */
+    public RawMultipartUploadRequest setBoundary(final String boundary) {
+        this.boundary = boundary;
+        return this;
+    }
+}

--- a/android/src/main/java/com/vydia/RawMultipartUploadTask.java
+++ b/android/src/main/java/com/vydia/RawMultipartUploadTask.java
@@ -1,0 +1,82 @@
+package com.vydia.RNUploader;
+
+import android.content.Intent;
+
+import net.gotev.uploadservice.HttpUploadTask;
+import net.gotev.uploadservice.NameValue;
+import net.gotev.uploadservice.UploadFile;
+import net.gotev.uploadservice.UploadService;
+import net.gotev.uploadservice.http.BodyWriter;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
+
+/**
+ * Implements an HTTP Multipart raw upload task.
+ *
+ * @author gotev (Aleksandar Gotev)
+ * @author eliasnaur
+ * @author cankov
+ * @author textile
+ */
+public class RawMultipartUploadTask extends HttpUploadTask {
+
+    protected static final String RAW_BOUNDARY = "rawMultipartBoundary";
+
+    @Override
+    protected void init(UploadService service, Intent intent) throws IOException {
+        super.init(service, intent);
+
+        String boundary = intent.getStringExtra(RAW_BOUNDARY);
+
+        httpParams.addRequestHeader("Connection", "close");
+        httpParams.addRequestHeader("Content-Type", "multipart/form-data; boundary=" + boundary);
+    }
+
+    @Override
+    protected long getBodyLength() throws UnsupportedEncodingException {
+        return getFilesLength();
+    }
+
+    @Override
+    public void onBodyReady(BodyWriter bodyWriter) throws IOException {
+        writeFiles(bodyWriter);
+    }
+
+    private long getFilesLength() throws UnsupportedEncodingException {
+        long total = 0;
+
+        for (UploadFile file : params.getFiles()) {
+            total += getTotalMultipartBytes(file);
+        }
+
+        return total;
+    }
+
+    private long getTotalMultipartBytes(UploadFile file)
+            throws UnsupportedEncodingException {
+        return file.length(service);
+    }
+
+    private void writeFiles(BodyWriter bodyWriter) throws IOException {
+        for (UploadFile file : params.getFiles()) {
+            if (!shouldContinue)
+                break;
+
+            final InputStream stream = file.getStream(service);
+            bodyWriter.writeStream(stream, this);
+            stream.close();
+        }
+    }
+
+    @Override
+    protected void onSuccessfulUpload() {
+        for (UploadFile file : params.getFiles()) {
+            addSuccessfullyUploadedFile(file.getPath());
+        }
+        params.getFiles().clear();
+    }
+
+}

--- a/android/src/main/java/com/vydia/UploaderModule.java
+++ b/android/src/main/java/com/vydia/UploaderModule.java
@@ -120,8 +120,8 @@ public class UploaderModule extends ReactContextBaseJavaModule {
         return;
       }
 
-      if (!requestType.equals("raw") && !requestType.equals("multipart")) {
-        promise.reject(new IllegalArgumentException("type should be string: raw or multipart."));
+      if (!requestType.equals("raw") && !requestType.equals("multipart") && !requestType.equals("raw-multipart")) {
+        promise.reject(new IllegalArgumentException("type should be string: raw, multipart, or raw-multipart."));
         return;
       }
     }
@@ -179,6 +179,20 @@ public class UploaderModule extends ReactContextBaseJavaModule {
       if (requestType.equals("raw")) {
         request = new BinaryUploadRequest(this.getReactApplicationContext(), customUploadId, url)
                 .setFileToUpload(filePath);
+      } else if (requestType.equals("raw-multipart")) {
+        if (!options.hasKey("boundary")) {
+          promise.reject(new IllegalArgumentException("boundary is required field for raw-multipart type."));
+          return;
+        }
+
+        if (options.getType("boundary") != ReadableType.String) {
+          promise.reject(new IllegalArgumentException("boundary must be string."));
+          return;
+        }
+
+        request = new RawMultipartUploadRequest(this.getReactApplicationContext(), customUploadId, url)
+                .setBoundary(options.getType("boundary"))
+                .setPayload(filePath);
       } else {
         if (!options.hasKey("field")) {
           promise.reject(new IllegalArgumentException("field is required field for multipart type."));
@@ -204,7 +218,7 @@ public class UploaderModule extends ReactContextBaseJavaModule {
       }
 
       if (options.hasKey("parameters")) {
-        if (requestType.equals("raw")) {
+        if (requestType.equals("raw") || requestType.equals("raw-multipart")) {
           promise.reject(new IllegalArgumentException("Parameters supported only in multipart type"));
           return;
         }

--- a/index.js
+++ b/index.js
@@ -14,17 +14,19 @@ export type StartUploadArgs = {
   url: string,
   path: string,
   // Optional, because raw is default
-  type?: 'raw' | 'multipart',
+  type?: 'raw' | 'multipart' | 'raw-multipart',
   // This option is needed for multipart type
   field?: string,
   customUploadId?: string,
   // parameters are supported only in multipart type
   parameters?: { [string]: string },
   headers?: Object,
-  notification?: NotificationArgs
+  notification?: NotificationArgs,
+  // boundary is supported only in raw-multipart type
+  boundary?: string
 }
 
-const NativeModule = NativeModules.VydiaRNFileUploader || NativeModules.RNFileUploader // iOS is VydiaRNFileUploader and Android is NativeModules 
+const NativeModule = NativeModules.VydiaRNFileUploader || NativeModules.RNFileUploader // iOS is VydiaRNFileUploader and Android is NativeModules
 const eventPrefix = 'RNFileUploader-'
 
 // for IOS, register event listeners or else they don't fire on DeviceEventEmitter
@@ -58,7 +60,7 @@ export const getFileInfo = (path: string): Promise<Object> => {
 }
 
 /*
-Starts uploading a file to an HTTP endpoint.  
+Starts uploading a file to an HTTP endpoint.
 Options object:
 {
   url: string.  url to post to.
@@ -96,7 +98,7 @@ export const cancelUpload = (cancelUploadId: string): Promise<boolean> => {
 }
 
 /*
-Listens for the given event on the given upload ID (resolved from startUpload).  
+Listens for the given event on the given upload ID (resolved from startUpload).
 If you don't supply a value for uploadId, the event will fire for all uploads.
 Events (id is always the upload ID):
   progress - { id: string, progress: int (0-100) }


### PR DESCRIPTION
Neither `raw` or `multipart` options let us send out self-constructed multipart payload file... 
- `multipart` option makes its own boundary
- `multipart` option builds its own payload body
- `raw` option jacks up raw payload